### PR TITLE
Fix action formula_id to be optional instead of computed

### DIFF
--- a/zabbix/resource_zabbix_action.go
+++ b/zabbix/resource_zabbix_action.go
@@ -1250,7 +1250,7 @@ func resourceZabbixActionRead(d *schema.ResourceData, meta interface{}) error {
 	d.Set("calculation", ActionEvaluationTypeStringMap[action.Filter.EvaluationType])
 	d.Set("formula", action.Filter.Formula)
 
-	conditions, err := readActionConditions(action.Filter.Conditions, api)
+	conditions, err := readActionConditions(action.Filter.Conditions, action.Filter.EvaluationType, api)
 	if err != nil {
 		return err
 	}
@@ -1278,7 +1278,7 @@ func resourceZabbixActionRead(d *schema.ResourceData, meta interface{}) error {
 	return nil
 }
 
-func readActionConditions(cds zabbix.ActionFilterConditions, api *zabbix.API) (lst []interface{}, err error) {
+func readActionConditions(cds zabbix.ActionFilterConditions, evaluationType zabbix.ActionEvaluationType, api *zabbix.API) (lst []interface{}, err error) {
 	for _, v := range cds {
 		m := map[string]interface{}{}
 		m["condition_id"] = v.ConditionID
@@ -1297,7 +1297,10 @@ func readActionConditions(cds zabbix.ActionFilterConditions, api *zabbix.API) (l
 
 		m["value"] = value
 		m["value2"] = v.Value2
-		m["formula_id"] = v.FormulaID
+		// Only save formula_id when calculation is "custom"
+		if evaluationType == zabbix.Custom {
+			m["formula_id"] = v.FormulaID
+		}
 		m["operator"] = ActionFilterConditionOperatorStringMap[v.Operator]
 
 		lst = append(lst, m)

--- a/zabbix/resource_zabbix_action.go
+++ b/zabbix/resource_zabbix_action.go
@@ -540,7 +540,7 @@ func resourceZabbixAction() *schema.Resource {
 						},
 						"formula_id": {
 							Type:     schema.TypeString,
-							Computed: true,
+							Optional: true,
 						},
 						"operator": {
 							Type:     schema.TypeString,
@@ -815,6 +815,7 @@ func createActionConditionObject(lst []interface{}, api *zabbix.API) (items zabb
 			ConditionType: StringActionConditionTypeMap[conditionType],
 			Value:         value,
 			Value2:        m["value2"].(string),
+			FormulaID:     m["formula_id"].(string),
 			Operator:      StringActionFilterConditionOperatorMap[m["operator"].(string)],
 		}
 		items = append(items, item)


### PR DESCRIPTION
## Problem

The Zabbix API requires `formula_id` to be specified during action creation when using custom expressions. However, the current implementation in `resource_zabbix_action.go` marks `formula_id` as `Computed: true` only, which prevents users from being able to specify this value themselves.

When a field is marked as `Computed` only in Terraform:
- The field value is determined by the provider/API after resource creation
- Users cannot explicitly set the value in their Terraform configuration
- This creates a conflict when the API actually requires the value during creation

## Solution

This PR changes `formula_id` to be both `Optional` and `Computed`:
- `Optional: true` - Allows users to explicitly specify `formula_id` when needed
- `Computed: true` - Maintains backward compatibility by allowing the value to be computed if not provided

This resolves the issue where users could not specify `formula_id` even though the API requires it during creation.